### PR TITLE
override move constructor for owned connection

### DIFF
--- a/fgl_signals/include/fgl/signals/connection.hpp
+++ b/fgl_signals/include/fgl/signals/connection.hpp
@@ -101,6 +101,14 @@ struct connection<SignalTpl<Signatures...>, Slot>
             }
         }
 
+        signal * get_signal() {
+            return psignal_;
+        }
+
+        const signal * get_signal() const {
+            return psignal_;
+        }
+
     private:
         auto add_raw_destruction_closure()
         {

--- a/fgl_signals/include/fgl/signals/owning_connection.hpp
+++ b/fgl_signals/include/fgl/signals/owning_connection.hpp
@@ -26,6 +26,13 @@ struct owning_connection
         {
         }
 
+        owning_connection(owning_connection&& other) 
+        : slot_(std::move(other.slot_))
+        , connection_(*other.connection_.get_signal(), slot_)
+        {
+            other.connection_.close();
+        }
+
         void close()
         {
             connection_.close();

--- a/test/src/tests/move_connection.hpp
+++ b/test/src/tests/move_connection.hpp
@@ -4,6 +4,7 @@
 #include <fgl/signals.hpp>
 #include <sstream>
 #include <string>
+#include <functional>
 
 namespace tests::move_connection
 {
@@ -31,15 +32,24 @@ bool test()
     );
     auto connection1b = std::move(connection1);
 
+    auto connection2 = sig.connect
+    (
+        std::function<void(int)>([&oss](const auto& value)
+        {
+            oss << "2" << value;
+        }
+    ));
+    auto connection2b = std::move(connection2);
     sig.emit(99);
 
     const auto expected_str =
         "099"
         "199"
+        "299"
     ;
-
     return oss.str() == expected_str;
 }
+
 
 } //namespace
 


### PR DESCRIPTION
A small change to fix moving a connection to a moved slot.
Tests added that previously throws `bad_function_call`
Required exposing access to signal, feel more than free to change the design to fit preferences. 